### PR TITLE
added a new PHP status section, and made sites print out PHP version

### DIFF
--- a/dashboard-default.php
+++ b/dashboard-default.php
@@ -23,6 +23,7 @@ $version = file_get_contents('/vagrant/version');
 				require_once( __DIR__ . '/php/blocks/main/bundled-environments-intro.php' );
 				require_once( __DIR__ . '/php/blocks/main/sites.php' );
 				require_once( __DIR__ . '/php/blocks/main/adding-site-doc.php' );
+				require_once( __DIR__ . '/php/blocks/main/php-status.php' );
 				?>
 			</div>
 			<div class="column right-column">

--- a/php/blocks/main/php-status.php
+++ b/php/blocks/main/php-status.php
@@ -4,13 +4,25 @@ $version = $version[0] . "." . $version[1] . "." . explode( '+', $version[2] )[0
 ?>
 <div class="box alt-box">
 	<h3>PHP Status</h3>
-	<p>The default version of PHP is <code>v<?php echo $version; ?></code>, but individual sites can use other versions of PHP.</p>
+
+	<p>The default version of PHP is <code>v<?php echo $version; ?></code>, but individual sites can use other versions of PHP. <a href="https://launchpad.net/~ondrej/+archive/ubuntu/php" target="_blank">PHP packages are installed from Ondřej Surý PPA</a></p>
+
+	<p>Update your <code>config/config.yml</code> file to install more versions of PHP</p>
+
 
 	<table>
 		<tr>
-			<th>PHP</th>
+			<th>PHP Installations</th>
 		</tr>
 <?php
+$files = glob('/usr/bin/php5.*');
+foreach ( $files as $file ) {
+	?>
+		<tr>
+			<td><?php echo basename( $file ) ?></td>
+		</tr>
+	<?php
+}
 $files = glob('/usr/bin/php7.*');
 foreach ( $files as $file ) {
 	?>
@@ -22,24 +34,34 @@ foreach ( $files as $file ) {
 ?>
 
 	</table>
+</div>
+<div class="box alt-box">
+	<h3>PHP Debug Extension</h3>
 
-	<table>
-		<tr>
-			<th>Debug Extension</th>
-			<th>Loaded</th>
-			<th>Version</th>
-		</tr>
-		<tr>
-			<td>XDebug</td>
-			<td><?php echo extension_loaded('xdebug') ? 'yes' : 'no'; ?></td>
-			<td><?php echo phpversion( 'xdebug' ); ?></td>
-		</tr>
-		<tr>
-			<td>Tideways/XHProf</td>
-			<td><?php echo extension_loaded('tideways_xhprof') ? 'yes' : 'no'; ?></td>
-			<td><?php echo phpversion( 'tideways_xhprof' ); ?></td>
-		</tr>
-	</table>
+<?php
+$exts = [
+	'XDebug'	=> 'xdebug',
+	'Tideways'  => 'tideways_xhprof',
+	'PCov'      => 'pcov',
+];
+$current_debug_ext = '';
+foreach ( $exts as $name => $ext ) {
+	if ( ! extension_loaded( $ext ) ) {
+		continue;
+	}
+	$current_debug_ext = $ext;
+	?>
+	<p>The currently loaded debugging extension for PHP is <strong><?php echo $name; ?></strong> at version <code><?php echo phpversion( 'xdebug' ); ?></code></p>
+	<?php
+	break;
+}
+if ( empty( $current_debug_ext ) ) {
+	?>
+	<p>No debugging extension is active at the moment</p>
+	<?php
+}
+?>
 
-	<p>To switch between debug mods, use <code>vagrant ssh</code> to enter the VM, then use <code>switch_php_debugmod</code> followed by the extension you prefer. For example to use XDebug, you would run <code>switch_php_debugmod xdebug</code>. On older versions of VVV you would need to use <code>xdebug_on</code> or <code>xdebug_off</code>.</p>
+	<p>To switch between debug extensions, use <code>vagrant ssh</code> to enter the VM, then use <code>switch_php_debugmod</code> followed by the extension you prefer. For example <code>switch_php_debugmod xdebug</code>. Use <code>switch_php_debugmod none</code> to disable them. On older versions of VVV you would need to use <code>xdebug_on</code> or <code>xdebug_off</code>.</p>
+	<p>All installs come with XDebug installed but turned off. Tideways can be added by modifying <code>config/config.yml</code></p>
 </div>

--- a/php/blocks/main/php-status.php
+++ b/php/blocks/main/php-status.php
@@ -1,0 +1,45 @@
+<?php
+$version = explode( '.', phpversion() );
+$version = $version[0] . "." . $version[1] . "." . explode( '+', $version[2] )[0];
+?>
+<div class="box alt-box">
+	<h3>PHP Status</h3>
+	<p>The default version of PHP is <code>v<?php echo $version; ?></code>, but individual sites can use other versions of PHP.</p>
+
+	<table>
+		<tr>
+			<th>PHP</th>
+		</tr>
+<?php
+$files = glob('/usr/bin/php7.*');
+foreach ( $files as $file ) {
+	?>
+		<tr>
+			<td><?php echo basename( $file ) ?></td>
+		</tr>
+	<?php
+}
+?>
+
+	</table>
+
+	<table>
+		<tr>
+			<th>Debug Extension</th>
+			<th>Loaded</th>
+			<th>Version</th>
+		</tr>
+		<tr>
+			<td>XDebug</td>
+			<td><?php echo extension_loaded('xdebug') ? 'yes' : 'no'; ?></td>
+			<td><?php echo phpversion( 'xdebug' ); ?></td>
+		</tr>
+		<tr>
+			<td>Tideways/XHProf</td>
+			<td><?php echo extension_loaded('tideways_xhprof') ? 'yes' : 'no'; ?></td>
+			<td><?php echo phpversion( 'tideways_xhprof' ); ?></td>
+		</tr>
+	</table>
+
+	<p>To switch between debug mods, use <code>vagrant ssh</code> to enter the VM, then use <code>switch_php_debugmod</code> followed by the extension you prefer. For example to use XDebug, you would run <code>switch_php_debugmod xdebug</code>. On older versions of VVV you would need to use <code>xdebug_on</code> or <code>xdebug_off</code>.</p>
+</div>

--- a/php/blocks/main/sites.php
+++ b/php/blocks/main/sites.php
@@ -13,6 +13,10 @@ function display_site( $name, array $site ) {
 	$classes = [];
 	$description = 'A WordPress installation';
 	$site_title = strip_tags( $name );
+	$upstream = 'php72';
+	if ( !empty( $site['nginx_upstream'] ) ) {
+		$upstream = $site['nginx_upstream'];
+	}
 	if( isset( $site['custom']['site_title'] ) ) {
 		$site_title = strip_tags( $site['custom']['site_title'] );
 	}
@@ -52,7 +56,8 @@ function display_site( $name, array $site ) {
 			}
 		}
 		?><br/>
-		<strong>Folder:</strong> <code>www/<?php echo strip_tags( $name ); ?></code></p>
+		<strong>Folder:</strong> <code>www/<?php echo strip_tags( $name ); ?></code><br/>
+		<strong>Using:</strong> <code><?php echo strip_tags( $upstream ); ?></code></p>
 		<?php
 		$warnings = [];
 		if ( $has_dev ) {

--- a/style.css
+++ b/style.css
@@ -174,6 +174,18 @@ input:focus,
 	background: #272b35;
 }
 
+table {
+	border-radius: 4px;
+	width: 100%;
+	text-align: left;
+}
+th {
+    border-bottom: 1px solid #ebcb8b
+}
+
+th, td {
+	padding: 10px 30px 10px 0px;
+}
 
 /**
  * Source Code Pro License and Copyright:


### PR DESCRIPTION
Shows the sites PHP version, and displays installed versions and extensions at the bottom.

<img width="504" alt="Screenshot 2020-03-14 at 17 26 10" src="https://user-images.githubusercontent.com/58855/76687158-3c4b3a00-6619-11ea-8172-cc744f746eac.png">
<img width="941" alt="Screenshot 2020-03-14 at 17 26 37" src="https://user-images.githubusercontent.com/58855/76687159-3ce3d080-6619-11ea-89aa-580054d49cd2.png">
