### PR TITLE
Updated styles for site links to display them as a list.

### DIFF
--- a/style.css
+++ b/style.css
@@ -237,8 +237,10 @@ input:hover,
 	background: #272b35;
 }
 
-.vvv-site-link + .vvv-site-link {
+.vvv-site-link {
+	display: list-item;
 	margin-left: 1em;
+	list-style: square;
 }
 
 .site-header-meta {

--- a/style.css
+++ b/style.css
@@ -238,9 +238,8 @@ input:hover,
 }
 
 .vvv-site-link {
-	display: list-item;
-	margin-left: 1em;
-	list-style: square;
+	display: inline-block;
+	margin-right: 1em;
 }
 
 .site-header-meta {


### PR DESCRIPTION
### CSS update to display site links as a list for any provisioned site.

This is useful if a site is provisioned with multiple domains. At present those domains are displayed in a single line which runs out of bounds and causes horizontal scrolling, as shown in screenshot below.

<img width="1424" alt="vvv-dashboard-out-of-bounds-links" src="https://user-images.githubusercontent.com/1511590/113066704-9f821d00-91d8-11eb-801d-e3cbf39f2108.png">

This CSS update will prevent the out-of-bounds display and horizontal scroll by displaying all domains for a site in a neat list, with all of them easily accessible (screenshot below).

<img width="1391" alt="vvv-dashboard-links-list" src="https://user-images.githubusercontent.com/1511590/113066839-d9532380-91d8-11eb-9743-3af438e84d74.png">
