### PR TITLE
Show utilities button by config file

### DIFF
--- a/php/blocks/main/sites.php
+++ b/php/blocks/main/sites.php
@@ -120,7 +120,7 @@ function display_site( $name, array $site ) : void {
 }
 
 function read_config() {
-    $config_locations = [
+	$config_locations = [
 		'/srv/vvv/config.yml',
 		'/vagrant/config.yml',
 		'/vagrant/vvv-custom.yml',

--- a/php/blocks/main/sites.php
+++ b/php/blocks/main/sites.php
@@ -119,9 +119,8 @@ function display_site( $name, array $site ) : void {
 	<?php
 }
 
-function display_sites() : void {
-	
-	$config_locations = [
+function read_config() {
+    $config_locations = [
 		'/srv/vvv/config.yml',
 		'/vagrant/config.yml',
 		'/vagrant/vvv-custom.yml',
@@ -136,6 +135,17 @@ function display_sites() : void {
 	}
 
 	if ( false === $config_file ) {
+		return false;
+	}
+
+	$yaml = new Alchemy\Component\Yaml\Yaml();
+	return $yaml->load( $config_file );
+}
+
+function display_sites() : void {
+	$data = read_config();
+
+	if ( false === $data ) {
 		echo '<p>No config file was found.</p>';
 		return;
 	}

--- a/php/blocks/sidebar/bundled-tools.php
+++ b/php/blocks/sidebar/bundled-tools.php
@@ -1,5 +1,6 @@
 <?php
-function is_utility_enabled( $search_utility ) {
+
+function is_utility_enabled( $search_utility ) : bool {
 	$data = read_config();
 	$found = false;
 	foreach ( $data['utilities'] as $suite => $utility ) {

--- a/php/blocks/sidebar/bundled-tools.php
+++ b/php/blocks/sidebar/bundled-tools.php
@@ -1,7 +1,7 @@
 <?php
 function is_utility_enabled( $search_utility ) {
 	$data = read_config();
-    $found = false;
+	$found = false;
 	foreach ( $data['utilities'] as $suite => $utility ) {
 		if (
 			isset( $utility[ $search_utility ] )

--- a/php/blocks/sidebar/bundled-tools.php
+++ b/php/blocks/sidebar/bundled-tools.php
@@ -1,26 +1,41 @@
+<?php
+function is_utility_enabled( $search_utility ) {
+	$data = read_config();
+    $found = false;
+	foreach ( $data['utilities'] as $suite => $utility ) {
+		if (
+			isset( $utility[ $search_utility ] )
+		) {
+			$found = true;
+		}
+	}
+
+	return $found;
+}
+?>
 <div class="box">
 	<h3>Tools</h3>
 	<nav class="tools">
 		<?php
-		if ( is_dir( '/srv/www/default/database-admin/' ) ) {
+		if ( is_utility_enabled( 'phpmyadmin' ) ) {
 			?>
 			<a class="button tool-phpmyadmin" href="//vvv.test/database-admin/" target="_blank">phpMyAdmin</a>
 			<?php
 		}
 
-		if ( is_dir( '/srv/www/default/memcached-admin/' ) ) {
+		if ( is_utility_enabled( 'memcached-admin' ) ) {
 			?>
 			<a class="button tool-memcached-admin" href="//vvv.test/memcached-admin/" target="_blank">phpMemcachedAdmin</a>
 			<?php
 		}
 
-		if ( is_dir( '/srv/www/default/opcache-status/' ) ) {
+		if ( is_utility_enabled( 'opcache-status' ) ) {
 			?>
 			<a class="button tool-opcachestatus" href="//vvv.test/opcache-status/opcache.php" target="_blank">Opcache Status</a>
 			<?php
 		}
 
-		if ( is_dir( '/srv/www/default/opcache-gui/' ) ) {
+		if ( is_utility_enabled( 'opcache-gui' ) ) {
 			?>
 			<a class="button tool-opcache-gui" href="//vvv.test/opcache-gui/" target="_blank">Opcache Gui</a>
 			<?php
@@ -36,12 +51,12 @@
 			<?php
 		}
 
-		if ( is_dir( '/srv/www/default/xhgui/' ) ) {
+		if ( is_utility_enabled( 'tideways' ) ) {
 			?>
 			<a class="button tool-xhgui" href="//xhgui.vvv.test/" target="_blank">XHGui Profiler</a>
 			<?php
 		}
-		if ( is_dir( '/srv/www/default/webgrind/' ) ) {
+		if ( is_utility_enabled( 'webgrind' ) ) {
 			?>
 			<a class="button tool-webgrind" href="//vvv.test/webgrind/" target="_blank">Webgrind</a>
 			<?php


### PR DESCRIPTION
As today the utilities looks for folders also if they are not provisioned in the config file.
This create https://github.com/Varying-Vagrant-Vagrants/VVV/issues/2289 but this can happen also with other utilities, they cannot have the domain dedicated but a folder yes and that can lead to 404 pages.

With this change look if it is provisioned and looking also for various repositories for utilities.

I didn't tested yet.