### PR TITLE
Fix undefined variable

### DIFF
--- a/php/blocks/main/sites.php
+++ b/php/blocks/main/sites.php
@@ -149,9 +149,6 @@ function display_sites() : void {
 		echo '<p>No config file was found.</p>';
 		return;
 	}
-	
-	$yaml = new Alchemy\Component\Yaml\Yaml();
-	$data = $yaml->load( $config_file );
 
 	$provisioned_sites = [];
 	$skipped_sites = [];


### PR DESCRIPTION
Notice: Undefined variable: config_file in /srv/www/default/dashboard/php/blocks/main/sites.php on line 154

Looks like this might have been introduced in #42.

$config_file is undefined in this scope, but shouldn't be needed because config has already been read and parsed via read_config().