### PR TITLE
"utilities" to "extensions"

### DIFF
--- a/php/blocks/sidebar/bundled-tools.php
+++ b/php/blocks/sidebar/bundled-tools.php
@@ -1,11 +1,11 @@
 <?php
 
-function is_utility_enabled( $search_utility ) : bool {
+function is_extension_enabled( $search_extension ) : bool {
 	$data = read_config();
 	$found = false;
-	foreach ( $data['utilities'] as $suite => $utility ) {
+	foreach ( $data['extensions'] as $suite => $extension ) {
 		if (
-			isset( $utility[ $search_utility ] )
+			isset( $extension[ $search_extension ] )
 		) {
 			$found = true;
 		}
@@ -18,25 +18,25 @@ function is_utility_enabled( $search_utility ) : bool {
 	<h3>Tools</h3>
 	<nav class="tools">
 		<?php
-		if ( is_utility_enabled( 'phpmyadmin' ) ) {
+		if ( is_extension_enabled( 'phpmyadmin' ) ) {
 			?>
 			<a class="button tool-phpmyadmin" href="//vvv.test/database-admin/" target="_blank">phpMyAdmin</a>
 			<?php
 		}
 
-		if ( is_utility_enabled( 'memcached-admin' ) ) {
+		if ( is_extension_enabled( 'memcached-admin' ) ) {
 			?>
 			<a class="button tool-memcached-admin" href="//vvv.test/memcached-admin/" target="_blank">phpMemcachedAdmin</a>
 			<?php
 		}
 
-		if ( is_utility_enabled( 'opcache-status' ) ) {
+		if ( is_extension_enabled( 'opcache-status' ) ) {
 			?>
 			<a class="button tool-opcachestatus" href="//vvv.test/opcache-status/opcache.php" target="_blank">Opcache Status</a>
 			<?php
 		}
 
-		if ( is_utility_enabled( 'opcache-gui' ) ) {
+		if ( is_extension_enabled( 'opcache-gui' ) ) {
 			?>
 			<a class="button tool-opcache-gui" href="//vvv.test/opcache-gui/" target="_blank">Opcache Gui</a>
 			<?php
@@ -52,12 +52,12 @@ function is_utility_enabled( $search_utility ) : bool {
 			<?php
 		}
 
-		if ( is_utility_enabled( 'tideways' ) ) {
+		if ( is_extension_enabled( 'tideways' ) ) {
 			?>
 			<a class="button tool-xhgui" href="//xhgui.vvv.test/" target="_blank">XHGui Profiler</a>
 			<?php
 		}
-		if ( is_utility_enabled( 'webgrind' ) ) {
+		if ( is_extension_enabled( 'webgrind' ) ) {
 			?>
 			<a class="button tool-webgrind" href="//vvv.test/webgrind/" target="_blank">Webgrind</a>
 			<?php

--- a/php/blocks/sidebar/bundled-tools.php
+++ b/php/blocks/sidebar/bundled-tools.php
@@ -1,18 +1,33 @@
 <?php
 
-function is_extension_enabled( $search_extension ) : bool {
+function is_extension_enabled( $search_extension ) {
 	$data = read_config();
-	$found = false;
-	foreach ( $data['extensions'] as $suite => $extension ) {
-		if (
-			isset( $extension[ $search_extension ] )
-		) {
-			$found = true;
+	
+	if ( empty( $data ) ) {
+		return false;
+	}
+	
+	if ( ! empty( $data['extensions'] ) ) {
+		// check the extensions section
+		foreach ( $data['extensions'] as $suite => $extension ) {
+			if ( isset( $extension[ $search_extension ] ) ) {
+				return true;
+			}
 		}
 	}
 
-	return $found;
+	if ( ! empty( $data['utilities'] ) ) {
+		// check the utilities fallback
+		foreach ( $data['utilities'] as $suite => $extension ) {
+			if ( isset( $extension[ $search_extension ] ) ) {
+				return true;
+			}
+		}
+	}
+
+	return false;
 }
+
 ?>
 <div class="box">
 	<h3>Tools</h3>
@@ -32,7 +47,7 @@ function is_extension_enabled( $search_extension ) : bool {
 
 		if ( is_extension_enabled( 'opcache-status' ) ) {
 			?>
-			<a class="button tool-opcachestatus" href="//vvv.test/opcache-status/opcache.php" target="_blank">Opcache Status</a>
+			<a class="button tool-opcache-status" href="//vvv.test/opcache-status/opcache.php" target="_blank">Opcache Status</a>
 			<?php
 		}
 
@@ -54,7 +69,7 @@ function is_extension_enabled( $search_extension ) : bool {
 
 		if ( is_extension_enabled( 'tideways' ) ) {
 			?>
-			<a class="button tool-xhgui" href="//xhgui.vvv.test/" target="_blank">XHGui Profiler</a>
+			<a class="button tool-xhgui tool-tideways" href="//xhgui.vvv.test/" target="_blank">XHGui Profiler</a>
 			<?php
 		}
 		if ( is_extension_enabled( 'webgrind' ) ) {
@@ -68,7 +83,7 @@ function is_extension_enabled( $search_extension ) : bool {
 		<?php
 		if ( extension_loaded( 'xdebug' ) && is_dir( '/srv/www/default/xdebuginfo/' ) ) {
 			?>
-			<a class="button tool-xdebuginfo" href="//vvv.test/xdebuginfo/" target="_blank">Xdebug Info</a>
+			<a class="button tool-xdebug tool-xdebuginfo" href="//vvv.test/xdebuginfo/" target="_blank">Xdebug Info</a>
 			<?php
 		}
 		?>


### PR DESCRIPTION
Looks like this bug might have been introduced in #42. I am seeing the following:

Notice: Undefined index: utilities in /srv/www/default/dashboard/php/blocks/sidebar/bundled-tools.php on line 6

Warning: Invalid argument supplied for foreach() in /srv/www/default/dashboard/php/blocks/sidebar/bundled-tools.php on line 6

"utilities" was renamed to "extensions" in Varying-Vagrant-Vagrants/VVV@5cea65ecca1c34ccd552c084f358a0366317b029.

I took the liberty of also changing other "utility" references to "extension".