### PR TITLE
Mid-provisioning warning fixes

### DIFF
--- a/dashboard-default.php
+++ b/dashboard-default.php
@@ -1,5 +1,9 @@
 <?php
-$version = file_get_contents( '/vagrant/version' );
+$version = 0;
+if ( file_exists( '/vagrant/version' ) && is_readable( '/vagrant/version' ) ) {
+	$version = file_get_contents( '/vagrant/version' );
+}
+
 $root_warning = file_exists( '/vagrant/provisioned_as_root' );
 
 ?><!DOCTYPE html>


### PR DESCRIPTION
This PR fixes some warnings and notices that happen when provisioning is in the early stages if you load vvv.test. The problems don't exist in a fully provisioned VM but we can tidy things up a little