### PR TITLE
Use in_array to check if extension enabled

### DIFF
--- a/php/blocks/sidebar/bundled-tools.php
+++ b/php/blocks/sidebar/bundled-tools.php
@@ -2,15 +2,15 @@
 
 function is_extension_enabled( $search_extension ) {
 	$data = read_config();
-	
+
 	if ( empty( $data ) ) {
 		return false;
 	}
-	
+
 	if ( ! empty( $data['extensions'] ) ) {
 		// check the extensions section
 		foreach ( $data['extensions'] as $suite => $extension ) {
-			if ( isset( $extension[ $search_extension ] ) ) {
+			if ( in_array( $search_extension, $extension, true ) ) {
 				return true;
 			}
 		}
@@ -19,7 +19,7 @@ function is_extension_enabled( $search_extension ) {
 	if ( ! empty( $data['utilities'] ) ) {
 		// check the utilities fallback
 		foreach ( $data['utilities'] as $suite => $extension ) {
-			if ( isset( $extension[ $search_extension ] ) ) {
+			if ( in_array( $search_extension, $extension, true ) ) {
 				return true;
 			}
 		}


### PR DESCRIPTION
I just noticed that enabled extensions aren't actually being displayed in the sidebar...

The extensions config is not keyed by extension name, but a list of extension names.