### PR TITLE
Distro info

### DIFF
--- a/php/blocks/sidebar/find-out-more-vvv.php
+++ b/php/blocks/sidebar/find-out-more-vvv.php
@@ -5,9 +5,11 @@
 		// note that at this time we cannot check for updates to be 100% sure,
 		// that requires a network connection which isn't always present
 		?>
-		<p>You're running VVV <code><?php echo trim( strip_tags( file_get_contents( '/vagrant/version' ) ) ); ?></code>, <strong>if</strong> there are updates available you can run <code>git pull</code> and reprovision to apply them</p>
+		<p>You're running VVV <code>v<?php echo trim( strip_tags( file_get_contents( '/vagrant/version' ) ) ); ?></code>, <strong>if</strong> there are updates available you can run <code>git pull</code> and <code>vagrant up --provision</code> to apply them.</p>
 		<?php
 	}
+	$distro_version = exec( 'lsb_release -ds' );
 	?>
+	<p>This VVV instance is inside a <?php echo $distro_version; ?> virtual machine.</p>
 	<a class="button" href="https://github.com/varying-vagrant-vagrants/vvv/" target="_blank">View the code on GitHub</a>
 </div>

--- a/php/blocks/sidebar/vvv1.php
+++ b/php/blocks/sidebar/vvv1.php
@@ -1,5 +1,5 @@
 <div class="box">
 	<h3>VVV 1.x Sites not Showing?</h3>
-	<p>Sites need to be listed in <code>vvv-custom.yml</code> for VVV to find them, luckily it's super easy and fast to add them back! click below to find out how to migrate your sites.</p>
+	<p>Sites need to be listed in <code>config/config.yml</code> for VVV to find them, luckily it's super easy and fast to add them back! click below to find out how to migrate your sites.</p>
 	<a class="button" href="https://varyingvagrantvagrants.org/docs/en-US/adding-a-new-site/migrating-from-vvv-1-4-x/">Migrating VVV 1 sites</a>
 </div>


### PR DESCRIPTION
Adds the current distro to the dashboard in the find out more section:

<img width="523" alt="Screenshot 2023-02-19 at 15 36 33" src="https://user-images.githubusercontent.com/58855/219958244-ef40e38d-7f76-4fe5-bdbc-5f058ba33dcd.png">

Adding this to lay the foundation for migrating those still using Ubuntu 18 to 22 in the future